### PR TITLE
cp sometimes needs sudo (case of minv2)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -138,7 +138,7 @@ update_perms() {
 }
 
 copy_bin_dir() {
-  cp $PROGDIR/bin/* /usr/local/bin/
+  $SUDO cp $PROGDIR/bin/* /usr/local/bin/
 }
 
 update_ssh_config() {


### PR DESCRIPTION
#99

if running minv2, the command fails due to permission denied... might be a good idea to throw in a $SUDO like several other commands in this file.