### PR TITLE
adds _push_post_job_envs() step

### DIFF
--- a/execute.py
+++ b/execute.py
@@ -142,15 +142,16 @@ class Execute(Base):
 
             env_results = []
             for filename in os.listdir(job_env_dir):
-                f = open(os.path.join(job_env_dir, filename), "r")
-                try:
-                    env_json = json.loads(f.read())
-                except ValueError as err:
-                    env_json = None
-                    self.log.error(
-                        'Error posting job envs: {0}'.format(str(err)))
-                if env_json is not None:
-                    env_results.append(env_json)
+                if filename.endswith(".json"):
+                    f = open(os.path.join(job_env_dir, filename), "r")
+                    try:
+                        env_json = json.loads(f.read())
+                    except ValueError as err:
+                        env_json = None
+                        self.log.error(
+                            'Error posting job envs: {0}'.format(str(err)))
+                    if env_json is not None:
+                        env_results.append(env_json)
 
             if env_results:
                 job['postJobEnvs'] = env_results

--- a/execute.py
+++ b/execute.py
@@ -118,12 +118,46 @@ class Execute(Base):
 
         self._push_test_results()
         self._push_coverage_results()
+        self._push_post_job_envs()
 
         return self.exit_code
 
     def _update_exit_code(self, new_exit_code):
         if self.exit_code is 0:
             self.exit_code = new_exit_code
+
+    def _push_post_job_envs(self):
+        self.log.debug('Inside _push_post_job_envs')
+        job_env_dir = '{0}/postjobenvs/'.format(
+            self.config['ARTIFACTS_DIR'])
+
+        if os.path.exists(job_env_dir):
+            self.log.debug('postJobEnvs exist, reading dir')
+
+            err, job = self.shippable_adapter.get_job_by_id(self.job_id)
+            if err is not None:
+                self.log.error('Failed to GET job_by_id: {0}, {1}'.format(
+                    self.job_id, err))
+                return
+
+            env_results = []
+            for filename in os.listdir(job_env_dir):
+                f = open(os.path.join(job_env_dir, filename), "r")
+                try:
+                    env_json = json.loads(f.read())
+                except ValueError as err:
+                    env_json = None
+                    self.log.error(
+                        'Error posting job envs: {0}'.format(str(err)))
+                if env_json is not None:
+                    env_results.append(env_json)
+
+            if env_results:
+                job['postJobEnvs'] = env_results
+
+            self.shippable_adapter.put_job_by_id(self.job_id, job)
+        else:
+            self.log.debug('No postJobEnvs exist, skipping')
 
     def _push_test_results(self):
         self.log.debug('Inside _push_test_reports')

--- a/shippable_adapter.py
+++ b/shippable_adapter.py
@@ -79,13 +79,13 @@ class ShippableAdapter(Base):
         }
         while True:
             try:
+                err = None
                 response = requests.put(
                     url,
                     data=json.dumps(body),
                     headers=headers)
                 self.log.debug('PUT {0} completed with {1}'.format(
                     url, response.status_code))
-                res_obj = json.loads(response.text)
                 if response.status_code >= 500:
                     # API server error, we must retry
                     err_msg = 'API server error: {0} {1}'.format(
@@ -93,6 +93,7 @@ class ShippableAdapter(Base):
                     raise Exception(err_msg)
                 elif response.status_code is not 200:
                     err = response.status_code
+                res_obj = json.loads(response.text)
                 return err, res_obj
             except Exception as exc:
                 trace = traceback.format_exc()


### PR DESCRIPTION
https://github.com/Shippable/cexec/issues/112


In the diagrams here https://github.com/Shippable/heap/issues/60#issue-145253399

* The PR pertains to the `cexec` portion of the design in **Diagram-2**

* The files read by `cexec` are generated by the script `_save_post_job_envs.sh` in **Diagram-1**