### PR TITLE
Only test-stringify each console line when the buffer stringify fails

### DIFF
--- a/script_runner.py
+++ b/script_runner.py
@@ -250,14 +250,6 @@ class ScriptRunner(Base):
                         'timestamp': timestamp,
                     }
 
-                    try:
-                        data = json.dumps(console_out)
-                    except Exception as exc:
-                        trace = traceback.format_exc()
-                        error = '{0}: {1}'.format(str(exc), trace)
-                        console_out['message'] = 'Failed to parse console log' \
-                            ' with error: {0}'.format(error)
-
                     if parent_id:
                         self.handle_console_output(console_out)
                     else:


### PR DESCRIPTION
https://github.com/Shippable/cexec/issues/138

Previously, we were stringifying each line of the console to test whether the console line could be parsed.
With this PR, we will...

- Attempt to stringify the whole list of jobConsoleModels that will be posted to api. If that succeeds, proceed with the post.
- If that attempt fails:
  - test-stringify each console line
  - when a console line is found that can't be parsed, substitute an error message for that console line.
  - Then, attempt to stringify the revised jobConsoleModels list again so it can be posted
  - If that attempt fails, log an error and don't post.

The result is that, for most console logs, we will only do a `json.dumps` once per console_buffer list - vs once per console line. 