### PR TITLE
Remove length based console flushing

### DIFF
--- a/script_runner.py
+++ b/script_runner.py
@@ -310,9 +310,6 @@ class ScriptRunner(Base):
         with self.console_buffer_lock:
             self.console_buffer.append(console_out)
 
-        if len(self.console_buffer) > self.config['CONSOLE_BUFFER_LENGTH']:
-            self.flush_console_buffer()
-
     def flush_console_buffer(self):
         if len(self.console_buffer) == 0:
             self.log.debug('No console output to flush')


### PR DESCRIPTION
The length based console flushing runs on the script runner thread which affects builds with large output.

I'll package all the binaries in a single PR after this is merged.

https://github.com/Shippable/cexec/issues/164